### PR TITLE
String serach bug fixes

### DIFF
--- a/src/main/java/com/openkappa/runtime/stringsearch/SparseBitMatrixSearcher.java
+++ b/src/main/java/com/openkappa/runtime/stringsearch/SparseBitMatrixSearcher.java
@@ -1,7 +1,5 @@
 package com.openkappa.runtime.stringsearch;
 
-import java.util.Arrays;
-
 public class SparseBitMatrixSearcher implements Searcher {
 
     private final long[] masks;
@@ -24,7 +22,6 @@ public class SparseBitMatrixSearcher implements Searcher {
         }
         this.masks = new long[cardinality + 1];
         this.positions = new byte[256];
-        Arrays.fill(positions, (byte)cardinality);
         int index = 0;
         for (byte key : searchString) {
             int position = rank(key, existence);
@@ -52,7 +49,7 @@ public class SparseBitMatrixSearcher implements Searcher {
         int value = (key & 0xFF);
         int wi = value >>> 6;
         int i = 0;
-        int position = 0;
+        int position = 1;
         while (i < wi) {
             position += Long.bitCount(existence[i]);
             ++i;

--- a/src/main/java/com/openkappa/runtime/stringsearch/UnsafeBitMatrixSearcher.java
+++ b/src/main/java/com/openkappa/runtime/stringsearch/UnsafeBitMatrixSearcher.java
@@ -29,8 +29,8 @@ public class UnsafeBitMatrixSearcher implements Searcher, AutoCloseable {
         UNSAFE.setMemory(masksOffset, 256 * Long.BYTES, (byte)0);
         long word = 1L;
         for (byte key : searchString) {
-            UNSAFE.putLong(masksOffset + (key & 0xFF),
-                    UNSAFE.getLong(masksOffset + (key & 0xFF)) | word);
+            UNSAFE.putLong(masksOffset + Long.BYTES * (key & 0xFF),
+                    UNSAFE.getLong(masksOffset + Long.BYTES * (key & 0xFF)) | word);
             word <<= 1;
         }
         this.success = 1L << (searchString.length - 1);
@@ -39,7 +39,7 @@ public class UnsafeBitMatrixSearcher implements Searcher, AutoCloseable {
     public int find(byte[] data) {
         long current = 0L;
         for (int i = 0; i < data.length; ++i) {
-            long mask = UNSAFE.getLong(masksOffset + (data[i] & 0xFF));
+            long mask = UNSAFE.getLong(masksOffset + Long.BYTES * (data[i] & 0xFF));
             current = ((current << 1) | 1) & mask;
             if ((current & success) == success) {
                 return i - Long.numberOfTrailingZeros(success);

--- a/src/main/java/com/openkappa/runtime/stringsearch/UnsafeSWARSparseBitMatrixSearcher.java
+++ b/src/main/java/com/openkappa/runtime/stringsearch/UnsafeSWARSparseBitMatrixSearcher.java
@@ -48,7 +48,8 @@ public class UnsafeSWARSparseBitMatrixSearcher implements Searcher, AutoCloseabl
         for (byte key : searchString) {
             int position = rank(key, existence);
             UNSAFE.putByte(positionsOffset + (key & 0xFF), (byte)position);
-            UNSAFE.putLong(masksOffset + position, UNSAFE.getLong(masksOffset + position) | (1L << index));
+            UNSAFE.putLong(masksOffset + Long.BYTES * position,
+                UNSAFE.getLong(masksOffset + Long.BYTES * position) | (1L << index));
             ++index;
         }
         this.success = 1L << (searchString.length - 1);
@@ -67,7 +68,7 @@ public class UnsafeSWARSparseBitMatrixSearcher implements Searcher, AutoCloseabl
                 for (int k = i + j; k < data.length; ++k) {
                     int value = data[k] & 0xFF;
                     int position = UNSAFE.getByte(positionsOffset + value) & 0xFF;
-                    long mask = UNSAFE.getLong(masksOffset + position);
+                    long mask = UNSAFE.getLong(masksOffset + Long.BYTES * position);
                     current = ((current << 1) | 1) & mask;
                     if (current == 0 && (k & (Long.BYTES - 1)) == 0) {
                         break;
@@ -81,7 +82,7 @@ public class UnsafeSWARSparseBitMatrixSearcher implements Searcher, AutoCloseabl
         for (; i < data.length; ++i) {
             int value = data[i] & 0xFF;
             int position = UNSAFE.getByte(positionsOffset + value) & 0xFF;
-            long mask = UNSAFE.getLong(masksOffset + position);
+            long mask = UNSAFE.getLong(masksOffset + Long.BYTES * position);
             current = ((current << 1) | 1) & mask;
             if ((current & success) == success) {
                 return i - Long.numberOfTrailingZeros(success);
@@ -94,7 +95,7 @@ public class UnsafeSWARSparseBitMatrixSearcher implements Searcher, AutoCloseabl
         int value = (key & 0xFF);
         int wi = value >>> 6;
         int i = 0;
-        int position = 0;
+        int position = 1;
         while (i < wi) {
             position += Long.bitCount(existence[i]);
             ++i;

--- a/src/main/java/com/openkappa/runtime/stringsearch/UnsafeSparseBitMatrixSearcher.java
+++ b/src/main/java/com/openkappa/runtime/stringsearch/UnsafeSparseBitMatrixSearcher.java
@@ -45,7 +45,8 @@ public class UnsafeSparseBitMatrixSearcher implements Searcher, AutoCloseable {
         for (byte key : searchString) {
             int position = rank(key, existence);
             UNSAFE.putByte(positionsOffset + (key & 0xFF), (byte)position);
-            UNSAFE.putLong(masksOffset + position, UNSAFE.getLong(masksOffset + position) | (1L << index));
+            UNSAFE.putLong(masksOffset + Long.BYTES * position,
+                UNSAFE.getLong(masksOffset + Long.BYTES * position) | (1L << index));
             ++index;
         }
         this.success = 1L << (searchString.length - 1);
@@ -56,7 +57,7 @@ public class UnsafeSparseBitMatrixSearcher implements Searcher, AutoCloseable {
         for (int i = 0; i < data.length; ++i) {
             int value = data[i] & 0xFF;
             int position = UNSAFE.getByte(positionsOffset + value) & 0xFF;
-            long mask = UNSAFE.getLong(masksOffset + position);
+            long mask = UNSAFE.getLong(masksOffset + Long.BYTES * position);
             current = ((current << 1) | 1) & mask;
             if ((current & success) == success) {
                 return i - Long.numberOfTrailingZeros(success);
@@ -69,7 +70,7 @@ public class UnsafeSparseBitMatrixSearcher implements Searcher, AutoCloseable {
         int value = (key & 0xFF);
         int wi = value >>> 6;
         int i = 0;
-        int position = 0;
+        int position = 1;
         while (i < wi) {
             position += Long.bitCount(existence[i]);
             ++i;


### PR DESCRIPTION
This fixes 2 issues:

1. Using sparse table position 0 for both the first byte and bytes not present in the `searchString`. Failing test:
`new UnsafeSparseBitMatrixSearcher("0".getBytes()).find("1".getBytes()); // 0`

2. `Unsafe.getLong` address calculation. Failing test:
`new UnsafeSparseBitMatrixSearcher("011111110".getBytes()).find("111111110".getBytes()); // 0`

The last one was causing unaligned 64 bit access, I wonder if there would be any effect on benchmark results.

IMHO [property based testing](https://github.com/linasm/string-search-algos/blob/blog-post-1/src/test/scala/search/engine/IndexOfTest.scala) for code like this is a must.
